### PR TITLE
Adding expected paths for vftrace.dll

### DIFF
--- a/yml/3rd_party/cyberark/vftrace.yml
+++ b/yml/3rd_party/cyberark/vftrace.yml
@@ -5,6 +5,8 @@ Created: 2022-10-17
 Vendor: CyberArk
 ExpectedLocations:
   - '%PROGRAMFILES%\CyberArk\Endpoint Privilege Manager\Agent\x32'
+  - '%PROGRAMFILES%\CyberArk\Endpoint Privilege Manager\Agent\x64'
+  - '%PROGRAMFILES%\CyberArk\Endpoint Privilege Manager\Agent'
 VulnerableExecutables:
   - Path: "vf_host.exe"
     SHA256:


### PR DESCRIPTION
Adding an x64 version and a architecture-agnostic location to the YAML file for vftrace.dl

For more information/evidence, see example vftrace.dll:
https://www.virustotal.com/gui/file/7884cf0ca457f9dad8da5c62ae843ae16696a742488b6a2a42966249682fa2d9/details vftrace.dll 