### PR TITLE
Add optional PE.VersionInformation attributes

### DIFF
--- a/.github/schema/schema.yml
+++ b/.github/schema/schema.yml
@@ -38,6 +38,38 @@ mapping:
         unique: true
         required: true
 
+  ExpectedVersionInformation:
+    type: seq
+    required: false
+    sequence:
+      - type: map
+        func: check_executables
+        mapping:
+            CompanyName:
+            type: str
+            required: false
+          FileDescription:
+            type: str
+            required: false
+          FileVersion:
+            type: str
+            required: false
+          InternalName:
+            type: str
+            required: false
+          LegalCopyright:
+            type: str
+            required: false
+          OriginalFilename:
+            type: str
+            required: false
+          ProductName:
+            type: str
+            required: false
+          ProductVersion:
+            type: str
+            required: false
+
   VulnerableExecutables:
     type: seq
     required: true
@@ -77,6 +109,31 @@ mapping:
                 required: true
 
           Variable:
+            type: str
+            required: false
+
+            CompanyName:
+            type: str
+            required: false
+          FileDescription:
+            type: str
+            required: false
+          FileVersion:
+            type: str
+            required: false
+          InternalName:
+            type: str
+            required: false
+          LegalCopyright:
+            type: str
+            required: false
+          OriginalFilename:
+            type: str
+            required: false
+          ProductName:
+            type: str
+            required: false
+          ProductVersion:
             type: str
             required: false
 

--- a/.github/schema/schema.yml
+++ b/.github/schema/schema.yml
@@ -45,7 +45,7 @@ mapping:
       - type: map
         func: check_executables
         mapping:
-            CompanyName:
+          CompanyName:
             type: str
             required: false
           FileDescription:
@@ -112,7 +112,7 @@ mapping:
             type: str
             required: false
 
-            CompanyName:
+          CompanyName:
             type: str
             required: false
           FileDescription:

--- a/.github/schema/schema.yml
+++ b/.github/schema/schema.yml
@@ -38,12 +38,12 @@ mapping:
         unique: true
         required: true
 
-  ExpectedVersionInformation:
+  ExpectedVersionInformation: &VersionInformation
     type: seq
     required: false
     sequence:
       - type: map
-        func: check_executables
+        func: not_empty
         mapping:
           CompanyName:
             type: str
@@ -112,30 +112,8 @@ mapping:
             type: str
             required: false
 
-          CompanyName:
-            type: str
-            required: false
-          FileDescription:
-            type: str
-            required: false
-          FileVersion:
-            type: str
-            required: false
-          InternalName:
-            type: str
-            required: false
-          LegalCopyright:
-            type: str
-            required: false
-          OriginalFilename:
-            type: str
-            required: false
-          ProductName:
-            type: str
-            required: false
-          ProductVersion:
-            type: str
-            required: false
+          ExpectedVersionInformation:
+            <<: *VersionInformation
 
   Resources:
     type: seq

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -11,6 +11,7 @@ A simple template can be found [here](/template.yml).
 | `Vendor` | String | ✅ |  | Name of the vendor providing the DLL. | 
 | `CVE` | String | Optional | CVE-YYYY-XXXX | ID of the assigned CVE, if applicable. |
 | `ExpectedLocations` | List[String] | Optional | No trailing slashes | Folder locations[^1] where legitimate versions of the DLL are normally found. |
+| `ExpectedVersionInformation` | [VersionInformation](#VersionInformation) | Optional | | File attributes of the legitimate DLL.|
 | `VulnerableExecutables` | List[[VulnerableExecutable](#VulnerableExecutable)] | ✅ |  | Executables that are known to load the DLL described. | 
 | `Resources` | List[String] | Optional | HTTP(S) links only | URLs to relevant content that may explain further context (e.g. a PDF report, a tweet, a YouTube video).|
 | `Acknowledgements` | List[[Acknowledgement](#Acknowledgement)] | Optional |  | People who should be acknowledge for finding this entry (i.e. who did the actual research). |
@@ -25,6 +26,19 @@ A simple template can be found [here](/template.yml).
 | `Condition` | String | Optional |  | If certain conditions are required for the attack to work, you can state them here. |
 | `SHA256` | List[String] | Optional | 64 characters | If the executable is 3rd-party (i.e. non-Microsoft), please add the SHA256 hash(es) of the executable here. |
 | `Variable` | String | Only when `Type` is set to `Environment Variable` | Should not contain percentage signs (`%`) | The environment variable name that can be hijacked. |
+| `ExpectedVersionInformation` | [VersionInformation](#VersionInformation) | Optional |  | File attributes of the legitimate executable.|
+
+## VersionInformation
+| Field | Type | Required | Format | Description |
+| ----- | ---- | -------- | ------ | ----------- |
+| CompanyName | String | Optional | | The `CompanyName` attribute of the PE file.|
+| FileDescription | String | Optional | | The `FileDescription` attribute of the PE file.|
+| FileVersion | String | Optional | | The `FileVersion` attribute of the PE file.|
+| InternalName | String | Optional | | The `InternalName` attribute of the PE file.|
+| LegalCopyright | String | Optional | | The `LegalCopyright` attribute of the PE file.|
+| OriginalFilename | String | Optional | | The `OriginalFilename` attribute of the PE file.|
+| ProductName | String | Optional | | The `ProductName` attribute of the PE file.|
+| ProductVersion | String | Optional | | The `ProductVersion` attribute of the PE file.|
 
 ## Acknowledgement
 | Field | Type | Required | Format | Description |

--- a/yml/3rd_party/avast/wsc.yml
+++ b/yml/3rd_party/avast/wsc.yml
@@ -1,10 +1,14 @@
 ---
 Name: wsc.dll
-Author: Matt Green 
+Author: Matt Green
 Created: 2022-08-15
 Vendor: Avast
 ExpectedLocations:
   - '%PROGRAMFILES%\AVAST Software\Avast'
+ExpectedVersionInformation:
+  - OriginalFilename: wsc.dll
+    InternalName: wsc
+    FileDescription: Avast security center dll
 VulnerableExecutables:
   - Path: wsc_proxy.exe
     SHA256:


### PR DESCRIPTION
Resubmitting the PE.VersionInformation schema discussed here -https://github.com/wietze/HijackLibs/pull/13

Removed regex requirement, we want to allow any ascii (removed redundant regex).
Added additional optional fields to both dll and host binary.