### PR TITLE
Normalize `tmdbglog.yml` to use "Trend Micro" in `Vendor` field

### DIFF
--- a/yml/3rd_party/trendmicro/tmdbglog.yml
+++ b/yml/3rd_party/trendmicro/tmdbglog.yml
@@ -2,7 +2,7 @@
 Name: tmdbglog.dll
 Author: Christiaan Beek
 Created: 2023-01-16
-Vendor: TrendMicro
+Vendor: Trend Micro
 ExpectedLocations:
   - '%PROGRAMFILES%\Trend Micro\Titanium'
 VulnerableExecutables:


### PR DESCRIPTION
- Older YAML files in `trendmicro` used "Trend Micro" as the vendor, whereas this one used "TrendMicro", therefore normalizing them to all be the same.