### PR TITLE
Add 4 new DLLs actively used ITW with search order hijacking

### DIFF
--- a/yml/3rd_party/asus/asio.yml
+++ b/yml/3rd_party/asus/asio.yml
@@ -1,6 +1,6 @@
 ---
 Name: asio.dll 
-Author: Jai Minton, HuntressLabs
+Author: Jai Minton - HuntressLabs
 Created: 2024-04-10
 Vendor: Asus
 ExpectedLocations: 
@@ -8,7 +8,7 @@ ExpectedLocations:
   - '%PROGRAMFILES(x86)%\ASUS\AXSP\%VERSION%'
 VulnerableExecutables:
   - Path: '%PROGRAMFILES(x86)%\ASUS\AXSP\4.02.12\atkexComSvc.exe'
-    Type: Sideloading|Search Order
+    Type: Sideloading
     ExpectedSignatureInformation:
       - Subject: C=TW, L=Taipei City, O=ASUSTeK Computer Inc., CN=ASUSTeK Computer Inc.
         Issuer: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert EV Code Signing CA (SHA2)

--- a/yml/3rd_party/asus/asio.yml
+++ b/yml/3rd_party/asus/asio.yml
@@ -1,13 +1,12 @@
 ---
-Name: asio.dll 
+Name: asio.dll
 Author: Jai Minton - HuntressLabs
 Created: 2024-04-10
 Vendor: Asus
-ExpectedLocations: 
+ExpectedLocations:
   - '%PROGRAMFILES%\ASUS\AXSP\%VERSION%'
-  - '%PROGRAMFILES(x86)%\ASUS\AXSP\%VERSION%'
 VulnerableExecutables:
-  - Path: '%PROGRAMFILES(x86)%\ASUS\AXSP\4.02.12\atkexComSvc.exe'
+  - Path: '%PROGRAMFILES%\ASUS\AXSP\4.02.12\atkexComSvc.exe'
     Type: Sideloading
     ExpectedSignatureInformation:
       - Subject: C=TW, L=Taipei City, O=ASUSTeK Computer Inc., CN=ASUSTeK Computer Inc.
@@ -17,7 +16,7 @@ VulnerableExecutables:
       - OriginalFilename: atkexComSvc.exe
         InternalName: atkexComSvc.exe
         FileDescription: ASUS Com Service
-    SHA256: 
+    SHA256:
       - '12c22ba646232d5d5087d0300d5cfd46fed424f26143a02dc866f1bfceab3c10'
 Resources:
   - https://www.virustotal.com/gui/file/006f91524d53d483074335f74c2ca2c10cab9b64de86f6151eedfa53174434f2/relations

--- a/yml/3rd_party/asus/asio.yml
+++ b/yml/3rd_party/asus/asio.yml
@@ -1,0 +1,27 @@
+---
+Name: asio.dll 
+Author: Jai Minton, HuntressLabs
+Created: 2024-04-10
+Vendor: Asus
+ExpectedLocations: 
+  - '%PROGRAMFILES%\ASUS\AXSP\%VERSION%'
+  - '%PROGRAMFILES(x86)%\ASUS\AXSP\%VERSION%'
+VulnerableExecutables:
+  - Path: '%PROGRAMFILES(x86)%\ASUS\AXSP\4.02.12\atkexComSvc.exe'
+    Type: Sideloading|Search Order
+    ExpectedSignatureInformation:
+      - Subject: C=TW, L=Taipei City, O=ASUSTeK Computer Inc., CN=ASUSTeK Computer Inc.
+        Issuer: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert EV Code Signing CA (SHA2)
+        Type: Authenticode
+    ExpectedVersionInformation:
+      - OriginalFilename: atkexComSvc.exe
+        InternalName: atkexComSvc.exe
+        FileDescription: ASUS Com Service
+    SHA256: 
+      - '12c22ba646232d5d5087d0300d5cfd46fed424f26143a02dc866f1bfceab3c10'
+Resources:
+  - https://www.virustotal.com/gui/file/006f91524d53d483074335f74c2ca2c10cab9b64de86f6151eedfa53174434f2/relations
+  - https://www.virustotal.com/gui/file/7f4689de97d97ddb6e788119ebf0dc3707c66f8216d7cbc79ea329d0c3df63bf/details
+Acknowledgements:
+  - Name: Jai Minton
+    Twitter: '@cyberrraiju'

--- a/yml/3rd_party/asus/asus_wmi.yml
+++ b/yml/3rd_party/asus/asus_wmi.yml
@@ -7,7 +7,7 @@ ExpectedLocations:
   - '%PROGRAMFILES%\ASUS\AXSP\%VERSION%'
   - '%PROGRAMFILES(x86)%\ASUS\AXSP\%VERSION%'
 VulnerableExecutables:
-  - Path: '%PROGRAMFILES(x86)%\ASUS\AXSP\4.02.12\atkexComSvc.exe'
+  - Path: '%PROGRAMFILES(x86)%\ASUS\AXSP\%VERSION%\atkexComSvc.exe'
     Type: Sideloading|Search Order
     ExpectedSignatureInformation:
       - Subject: C=TW, L=Taipei City, O=ASUSTeK Computer Inc., CN=ASUSTeK Computer Inc.
@@ -24,4 +24,4 @@ Resources:
   - https://www.virustotal.com/gui/file/7f4689de97d97ddb6e788119ebf0dc3707c66f8216d7cbc79ea329d0c3df63bf/details
 Acknowledgements:
   - Name: Jai Minton
-    Twitter: '@cyberrraiju'
+    Twitter: '@cyberrraiju' 

--- a/yml/3rd_party/asus/asus_wmi.yml
+++ b/yml/3rd_party/asus/asus_wmi.yml
@@ -1,13 +1,12 @@
 ---
-Name: asus_wmi.dll 
+Name: asus_wmi.dll
 Author: Jai Minton - HuntressLabs
 Created: 2024-04-10
 Vendor: Asus
-ExpectedLocations: 
+ExpectedLocations:
   - '%PROGRAMFILES%\ASUS\AXSP\%VERSION%'
-  - '%PROGRAMFILES(x86)%\ASUS\AXSP\%VERSION%'
 VulnerableExecutables:
-  - Path: '%PROGRAMFILES(x86)%\ASUS\AXSP\%VERSION%\atkexComSvc.exe'
+  - Path: '%PROGRAMFILES%\ASUS\AXSP\%VERSION%\atkexComSvc.exe'
     Type: Sideloading
     ExpectedSignatureInformation:
       - Subject: C=TW, L=Taipei City, O=ASUSTeK Computer Inc., CN=ASUSTeK Computer Inc.
@@ -17,11 +16,11 @@ VulnerableExecutables:
       - OriginalFilename: atkexComSvc.exe
         InternalName: atkexComSvc.exe
         FileDescription: ASUS Com Service
-    SHA256: 
+    SHA256:
       - '12c22ba646232d5d5087d0300d5cfd46fed424f26143a02dc866f1bfceab3c10'
 Resources:
   - https://www.virustotal.com/gui/file/006f91524d53d483074335f74c2ca2c10cab9b64de86f6151eedfa53174434f2/relations
   - https://www.virustotal.com/gui/file/7f4689de97d97ddb6e788119ebf0dc3707c66f8216d7cbc79ea329d0c3df63bf/details
 Acknowledgements:
   - Name: Jai Minton
-    Twitter: '@cyberrraiju' 
+    Twitter: '@cyberrraiju'

--- a/yml/3rd_party/asus/asus_wmi.yml
+++ b/yml/3rd_party/asus/asus_wmi.yml
@@ -1,0 +1,27 @@
+---
+Name: asus_wmi.dll 
+Author: Jai Minton, HuntressLabs
+Created: 2024-04-10
+Vendor: Asus
+ExpectedLocations: 
+  - '%PROGRAMFILES%\ASUS\AXSP\%VERSION%'
+  - '%PROGRAMFILES(x86)%\ASUS\AXSP\%VERSION%'
+VulnerableExecutables:
+  - Path: '%PROGRAMFILES(x86)%\ASUS\AXSP\4.02.12\atkexComSvc.exe'
+    Type: Sideloading|Search Order
+    ExpectedSignatureInformation:
+      - Subject: C=TW, L=Taipei City, O=ASUSTeK Computer Inc., CN=ASUSTeK Computer Inc.
+        Issuer: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert EV Code Signing CA (SHA2)
+        Type: Authenticode
+    ExpectedVersionInformation:
+      - OriginalFilename: atkexComSvc.exe
+        InternalName: atkexComSvc.exe
+        FileDescription: ASUS Com Service
+    SHA256: 
+      - '12c22ba646232d5d5087d0300d5cfd46fed424f26143a02dc866f1bfceab3c10'
+Resources:
+  - https://www.virustotal.com/gui/file/006f91524d53d483074335f74c2ca2c10cab9b64de86f6151eedfa53174434f2/relations
+  - https://www.virustotal.com/gui/file/7f4689de97d97ddb6e788119ebf0dc3707c66f8216d7cbc79ea329d0c3df63bf/details
+Acknowledgements:
+  - Name: Jai Minton
+    Twitter: '@cyberrraiju'

--- a/yml/3rd_party/asus/asus_wmi.yml
+++ b/yml/3rd_party/asus/asus_wmi.yml
@@ -1,6 +1,6 @@
 ---
 Name: asus_wmi.dll 
-Author: Jai Minton, HuntressLabs
+Author: Jai Minton - HuntressLabs
 Created: 2024-04-10
 Vendor: Asus
 ExpectedLocations: 
@@ -8,7 +8,7 @@ ExpectedLocations:
   - '%PROGRAMFILES(x86)%\ASUS\AXSP\%VERSION%'
 VulnerableExecutables:
   - Path: '%PROGRAMFILES(x86)%\ASUS\AXSP\%VERSION%\atkexComSvc.exe'
-    Type: Sideloading|Search Order
+    Type: Sideloading
     ExpectedSignatureInformation:
       - Subject: C=TW, L=Taipei City, O=ASUSTeK Computer Inc., CN=ASUSTeK Computer Inc.
         Issuer: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert EV Code Signing CA (SHA2)

--- a/yml/3rd_party/cisco/wcldll.yml
+++ b/yml/3rd_party/cisco/wcldll.yml
@@ -1,0 +1,24 @@
+---
+Name: wcldll.dll 
+Author: Jai Minton, HuntressLabs
+Created: 2024-04-10
+Vendor: Cisco
+ExpectedLocations: 
+  - '%PROGRAMFILES(x86)%\Cisco Systems\Cisco Jabber'
+  - '%PROGRAMFILES(x86)%\webex\'
+VulnerableExecutables:
+  - Path: '%PROGRAMFILES(x86)%\webex\ptInst.exe'
+    Type: Sideloading|Search Order
+    ExpectedVersionInformation:
+      - OriginalFilename: ptInst.exe
+        InternalName: ptInst
+        FileDescription: WebEx PT ptInst Module
+    SHA256: 
+      - 'bf1a0c67b433f52ebd304553f022baa34bfbca258c932d2b4b8b956b1467bfa5'
+Resources:
+  - https://www.virustotal.com/gui/file/bf1a0c67b433f52ebd304553f022baa34bfbca258c932d2b4b8b956b1467bfa5/details
+  - https://www.virustotal.com/gui/file/26227914bdad9baf491a9b966e6301fc997cff35c677dcfd9628654f4f6bc9fc/relations
+  - https://www.virustotal.com/gui/file/fa1443219f210bdcf3a25b311342851f61378536eb11810366468156fbd5c051
+Acknowledgements:
+  - Name: Jai Minton
+    Twitter: '@cyberrraiju' 

--- a/yml/3rd_party/cisco/wcldll.yml
+++ b/yml/3rd_party/cisco/wcldll.yml
@@ -5,9 +5,10 @@ Created: 2024-04-10
 Vendor: Cisco
 ExpectedLocations: 
   - '%PROGRAMFILES(x86)%\Cisco Systems\Cisco Jabber'
-  - '%PROGRAMFILES(x86)%\webex'
+  - '%PROGRAMFILES(x86)%\Webex\Applications'
+  - '%PROGRAMFILES(x86)%\Webex\Plugins'
 VulnerableExecutables:
-  - Path: '%PROGRAMFILES(x86)%\webex\ptInst.exe'
+  - Path: '%PROGRAMFILES(x86)%\Webex\Applications\ptInst.exe'
     Type: Sideloading
     ExpectedVersionInformation:
       - OriginalFilename: ptInst.exe

--- a/yml/3rd_party/cisco/wcldll.yml
+++ b/yml/3rd_party/cisco/wcldll.yml
@@ -1,6 +1,6 @@
 ---
 Name: wcldll.dll 
-Author: Jai Minton, HuntressLabs
+Author: Jai Minton - HuntressLabs
 Created: 2024-04-10
 Vendor: Cisco
 ExpectedLocations: 
@@ -8,7 +8,7 @@ ExpectedLocations:
   - '%PROGRAMFILES(x86)%\webex\'
 VulnerableExecutables:
   - Path: '%PROGRAMFILES(x86)%\webex\ptInst.exe'
-    Type: Sideloading|Search Order
+    Type: Sideloading
     ExpectedVersionInformation:
       - OriginalFilename: ptInst.exe
         InternalName: ptInst

--- a/yml/3rd_party/cisco/wcldll.yml
+++ b/yml/3rd_party/cisco/wcldll.yml
@@ -1,20 +1,20 @@
 ---
-Name: wcldll.dll 
+Name: wcldll.dll
 Author: Jai Minton - HuntressLabs
 Created: 2024-04-10
 Vendor: Cisco
-ExpectedLocations: 
-  - '%PROGRAMFILES(x86)%\Cisco Systems\Cisco Jabber'
-  - '%PROGRAMFILES(x86)%\Webex\Applications'
-  - '%PROGRAMFILES(x86)%\Webex\Plugins'
+ExpectedLocations:
+  - '%PROGRAMFILES%\Cisco Systems\Cisco Jabber'
+  - '%PROGRAMFILES%\Webex\Applications'
+  - '%PROGRAMFILES%\Webex\Plugins'
 VulnerableExecutables:
-  - Path: '%PROGRAMFILES(x86)%\Webex\Applications\ptInst.exe'
+  - Path: '%PROGRAMFILES%\Webex\Applications\ptInst.exe'
     Type: Sideloading
     ExpectedVersionInformation:
       - OriginalFilename: ptInst.exe
         InternalName: ptInst
         FileDescription: WebEx PT ptInst Module
-    SHA256: 
+    SHA256:
       - 'bf1a0c67b433f52ebd304553f022baa34bfbca258c932d2b4b8b956b1467bfa5'
 Resources:
   - https://www.virustotal.com/gui/file/bf1a0c67b433f52ebd304553f022baa34bfbca258c932d2b4b8b956b1467bfa5/details
@@ -22,4 +22,4 @@ Resources:
   - https://www.virustotal.com/gui/file/fa1443219f210bdcf3a25b311342851f61378536eb11810366468156fbd5c051
 Acknowledgements:
   - Name: Jai Minton
-    Twitter: '@cyberrraiju' 
+    Twitter: '@cyberrraiju'

--- a/yml/3rd_party/cisco/wcldll.yml
+++ b/yml/3rd_party/cisco/wcldll.yml
@@ -5,7 +5,7 @@ Created: 2024-04-10
 Vendor: Cisco
 ExpectedLocations: 
   - '%PROGRAMFILES(x86)%\Cisco Systems\Cisco Jabber'
-  - '%PROGRAMFILES(x86)%\webex\'
+  - '%PROGRAMFILES(x86)%\webex'
 VulnerableExecutables:
   - Path: '%PROGRAMFILES(x86)%\webex\ptInst.exe'
     Type: Sideloading

--- a/yml/3rd_party/glorylogic/badata_x64.yml
+++ b/yml/3rd_party/glorylogic/badata_x64.yml
@@ -3,18 +3,18 @@ Name: badata_x64.dll
 Author: Jai Minton - HuntressLabs
 Created: 2024-04-10
 Vendor: Glorylogic
-ExpectedLocations: 
+ExpectedLocations:
   - '%PROGRAMFILES%\True Burner'
 VulnerableExecutables:
   - Path: '%PROGRAMFILES%\True Burner\TrueBurner.exe'
     Type: Sideloading
     ExpectedVersionInformation:
       - FileDescription: True Burner
-    SHA256: 
+    SHA256:
       - '3e190f160218ad78c85c169dfd0828d36e4a366a3e2a61337391f0d7599a7558'
 Resources:
   - https://www.virustotal.com/gui/file/3e190f160218ad78c85c169dfd0828d36e4a366a3e2a61337391f0d7599a7558/relations
   - https://www.virustotal.com/gui/file/9326dd40e37d720f15a0104f89d6e76eb7a75b6e1fad14018326dbaa01681e74/relations
 Acknowledgements:
   - Name: Jai Minton
-    Twitter: '@cyberrraiju' 
+    Twitter: '@cyberrraiju'

--- a/yml/3rd_party/glorylogic/badata_x64.yml
+++ b/yml/3rd_party/glorylogic/badata_x64.yml
@@ -10,7 +10,6 @@ VulnerableExecutables:
     Type: Sideloading
     ExpectedVersionInformation:
       - FileDescription: True Burner
-        Comments: http://www.glorylogic.com
     SHA256: 
       - '3e190f160218ad78c85c169dfd0828d36e4a366a3e2a61337391f0d7599a7558'
 Resources:

--- a/yml/3rd_party/glorylogic/badata_x64.yml
+++ b/yml/3rd_party/glorylogic/badata_x64.yml
@@ -1,13 +1,13 @@
 ---
 Name: badata_x64.dll
-Author: Jai Minton, HuntressLabs
+Author: Jai Minton - HuntressLabs
 Created: 2024-04-10
 Vendor: Cisco
 ExpectedLocations: 
   - '%PROGRAMFILES%\True Burner'
 VulnerableExecutables:
   - Path: '%PROGRAMFILES%\True Burner\TrueBurner.exe'
-    Type: Sideloading|Search Order
+    Type: Sideloading
     ExpectedVersionInformation:
       - FileDescription: True Burner
         Comments: http://www.glorylogic.com

--- a/yml/3rd_party/glorylogic/badata_x64.yml
+++ b/yml/3rd_party/glorylogic/badata_x64.yml
@@ -2,7 +2,7 @@
 Name: badata_x64.dll
 Author: Jai Minton - HuntressLabs
 Created: 2024-04-10
-Vendor: Cisco
+Vendor: Glorylogic
 ExpectedLocations: 
   - '%PROGRAMFILES%\True Burner'
 VulnerableExecutables:

--- a/yml/3rd_party/glorylogic/badata_x64.yml
+++ b/yml/3rd_party/glorylogic/badata_x64.yml
@@ -1,0 +1,21 @@
+---
+Name: badata_x64.dll
+Author: Jai Minton, HuntressLabs
+Created: 2024-04-10
+Vendor: Cisco
+ExpectedLocations: 
+  - '%PROGRAMFILES%\True Burner'
+VulnerableExecutables:
+  - Path: '%PROGRAMFILES%\True Burner\TrueBurner.exe'
+    Type: Sideloading|Search Order
+    ExpectedVersionInformation:
+      - FileDescription: True Burner
+        Comments: http://www.glorylogic.com
+    SHA256: 
+      - '3e190f160218ad78c85c169dfd0828d36e4a366a3e2a61337391f0d7599a7558'
+Resources:
+  - https://www.virustotal.com/gui/file/3e190f160218ad78c85c169dfd0828d36e4a366a3e2a61337391f0d7599a7558/relations
+  - https://www.virustotal.com/gui/file/9326dd40e37d720f15a0104f89d6e76eb7a75b6e1fad14018326dbaa01681e74/relations
+Acknowledgements:
+  - Name: Jai Minton
+    Twitter: '@cyberrraiju' 


### PR DESCRIPTION
New entries.
**Cisco:** wcldll.dll seen loaded into ptInst.exe. The exact vulnerable path where this resides was pieced together from multiple sources and is technically unknown. This has been seen maliciously residing in the directory appdata\roaming\microsoft\windows\Roaming\mibincodec\ptInst.exe
**Asus:** asus_wmi.dll and asio.dll both have been seen loaded into renamed executables of atkexComSvc.exe such as TPAutoConnect.exe. This has been seen maliciously residing within subdirectories of AppData\Local\ 
**Glorylogic:** badata_x64.dll seen loaded into TrueBurner.exe. This has been seen maliciously residing in subdirectories of ProgramData\