### PR TITLE
Keyscrambler.exe side-loading KeyScramblerIE.dll

### DIFF
--- a/yml/3rd_party/keyscrambler/keyscramblerie.yml
+++ b/yml/3rd_party/keyscrambler/keyscramblerie.yml
@@ -1,0 +1,24 @@
+---
+Name: keyscramblerie.dll
+Author: Swachchhanda Shrawan Poudel
+Created: 2023-01-01
+Vendor: QFX Software Corporation
+ExpectedLocations:
+  - '%PROGRAMFILES%\KeyScrambler'
+VulnerableExecutables:
+  - Path: '%PROGRAMFILES%\KeyScrambler\KeyScrambler.exe'
+    Type: Sideloading
+    SHA256:
+      - 'f1575259753f52aaabbd6baad3069605d764761c1da92e402f3e781ed3cf7cea'
+      - 'fa7ad2f45128120bccc33f996f87a81faa2e9c1236666dd69b943a755f332eb1'
+Resources:
+  - https://thehackernews.com/2024/03/two-chinese-apt-groups-ramp-up-cyber.html
+  - https://csirt-cti.net/2024/02/01/stately-taurus-continued-new-information-on-cyberespionage-attacks-against-myanmar-military-junta/
+  - https://bazaar.abuse.ch/sample/5cb9876681f78d3ee8a01a5aaa5d38b05ec81edc48b09e3865b75c49a2187831/
+  - https://twitter.com/Max_Mal_/status/1775222576639291859
+  - https://twitter.com/DTCERT/status/1712785426895839339
+  - https://www.virustotal.com/gui/file/5cb9876681f78d3ee8a01a5aaa5d38b05ec81edc48b09e3865b75c49a2187831/details
+  - https://www.virustotal.com/gui/file/9cfdc3fe2a10fe2b514fc224c9c8740e1de039d90b9c17f85b64ff29d4a4ebb1
+Acknowledgements:
+  - Name: Swachchhanda Shrawan Poudel
+    Twitter: '@_swachchhanda_'

--- a/yml/3rd_party/qfx/keyscramblerie.yml
+++ b/yml/3rd_party/qfx/keyscramblerie.yml
@@ -1,7 +1,7 @@
 ---
 Name: keyscramblerie.dll
 Author: Swachchhanda Shrawan Poudel
-Created: 2023-01-01
+Created: 2024-04-15
 Vendor: QFX
 ExpectedLocations:
   - '%PROGRAMFILES%\KeyScrambler'

--- a/yml/3rd_party/qfx/keyscramblerie.yml
+++ b/yml/3rd_party/qfx/keyscramblerie.yml
@@ -2,7 +2,7 @@
 Name: keyscramblerie.dll
 Author: Swachchhanda Shrawan Poudel
 Created: 2023-01-01
-Vendor: QFX Software Corporation
+Vendor: QFX
 ExpectedLocations:
   - '%PROGRAMFILES%\KeyScrambler'
 VulnerableExecutables:


### PR DESCRIPTION
KeyScrambler.exe has been seen abused to side-load the malicious DLL in the variants of Darkgate, Chinese APTs TTps. etc. Here is a sigma rule to detect this behavior
https://github.com/SigmaHQ/sigma/blob/b40d86599ce8c33bbfc78085e8703e827d92a4b1/rules/windows/image_load/image_load_side_load_keyscrambler.yml