### PR TITLE
Update drvstore.yml

### DIFF
--- a/yml/microsoft/built-in/drvstore.yml
+++ b/yml/microsoft/built-in/drvstore.yml
@@ -32,7 +32,7 @@ VulnerableExecutables:
 Resources:
 - https://securityintelligence.com/posts/windows-features-dll-sideloading/
 - https://github.com/xforcered/WFH
-- https://www.microsoft.com/en-us/download/details.aspx?id=105437 (HVCIScan Download)
+- https://www.microsoft.com/en-us/download/details.aspx?id=105437
 Acknowledgements:
 - Name: Chris Spehn
   Twitter: '@ConsciousHacker'

--- a/yml/microsoft/built-in/drvstore.yml
+++ b/yml/microsoft/built-in/drvstore.yml
@@ -23,9 +23,16 @@ VulnerableExecutables:
   - Subject: CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     Issuer: CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     Type: Catalog
+- Path: 'hvciscan_amd64.exe'
+  Type: Sideloading
+  ExpectedSignatureInformation:
+  - Subject: CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
+    Issuer: CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
+    Type: Catalog
 Resources:
 - https://securityintelligence.com/posts/windows-features-dll-sideloading/
 - https://github.com/xforcered/WFH
+- https://www.microsoft.com/en-us/download/details.aspx?id=105437 (HVCIScan Download)
 Acknowledgements:
 - Name: Chris Spehn
   Twitter: '@ConsciousHacker'


### PR DESCRIPTION
The Microsoft-signed executable hvciscan_amd64.exe attempts to execute the function 'DriverStoreOpenW' in drvstore.dll in the current directory. Since this is a stand-alone tool  (https://www.microsoft.com/en-us/download/details.aspx?id=105437) it doesn't have an expected location.