### PR TITLE
Add zlibwapi.yml

### DIFF
--- a/yml/3rd_party/zlib/zlibwapi.yml
+++ b/yml/3rd_party/zlib/zlibwapi.yml
@@ -4,7 +4,7 @@ Author: Still Hsu
 Created: 2024-11-24
 Vendor: zlib
 ExpectedLocations:
-  - '%programfiles%\DS Clock'
+  - '%PROGRAMFILES%\DS Clock'
 VulnerableExecutables:
 - Path: '%PROGRAMFILES%\DS Clock\dsclock.exe'
   Type: Sideloading
@@ -22,7 +22,7 @@ VulnerableExecutables:
   SHA256:
   - f85ce4492e1354f8310027c5f70ef73aae654fcd8fd9a58034e4f82a41a9826b
 Resources:
-  - https://x.com/malwrhunterteam/status/1859316170773397966
+  - https://twitter.com/malwrhunterteam/status/1859316170773397966
   - https://www.virustotal.com/gui/file/b8d38fc9f4560719fa64227e4b25b732b22602cb596d44cb38418a196c3340be
   - https://github.com/Still34/malware-lab/tree/main/reworkshop/2024-11-24
 Acknowledgements:

--- a/yml/3rd_party/zlib/zlibwapi.yml
+++ b/yml/3rd_party/zlib/zlibwapi.yml
@@ -24,11 +24,9 @@ VulnerableExecutables:
 Resources:
   - https://x.com/malwrhunterteam/status/1859316170773397966
   - https://www.virustotal.com/gui/file/b8d38fc9f4560719fa64227e4b25b732b22602cb596d44cb38418a196c3340be
-  - https://www.virustotal.com/gui/file/f85ce4492e1354f8310027c5f70ef73aae654fcd8fd9a58034e4f82a41a9826b/relations
   - https://github.com/Still34/malware-lab/tree/main/reworkshop/2024-11-24
 Acknowledgements:
   - Name: MalwareHunterTeam
     Twitter: '@malwrhunterteam'
   - Name: Still Hsu
     Twitter: '@AzakaSekai_'
-

--- a/yml/3rd_party/zlib/zlibwapi.yml
+++ b/yml/3rd_party/zlib/zlibwapi.yml
@@ -1,0 +1,34 @@
+---
+Name: zlibwapi.dll
+Author: Still Hsu
+Created: 2024-11-24
+Vendor: zlib
+ExpectedLocations:
+  - '%programfiles%\DS Clock'
+VulnerableExecutables:
+- Path: '%PROGRAMFILES%\DS Clock\dsclock.exe'
+  Type: Sideloading
+  ExpectedVersionInformation:
+  - FileDescription: DS Clock
+    LegalCopyright: Copyright ©️ 2001-2023 Duality Software. All rights reserved. Developed by Vladimir Kulemin.
+    InternalName: dsclock.exe
+    OriginalFilename: dsclock.exe
+    ProductName: DS Clock
+    ProductVersion: 5.1.2.0
+  ExpectedSignatureInformation:
+  - Subject: CN=Duality Software LLC, O=Duality Software LLC, L=Saint Petersburg, S=Saint Petersburg, C=RU
+    Issuer: CN=GlobalSign GCC R45 CodeSigning CA 2020, O=GlobalSign nv-sa, C=BE
+    Type: Authenticode
+  SHA256:
+  - f85ce4492e1354f8310027c5f70ef73aae654fcd8fd9a58034e4f82a41a9826b
+Resources:
+  - https://x.com/malwrhunterteam/status/1859316170773397966
+  - https://www.virustotal.com/gui/file/b8d38fc9f4560719fa64227e4b25b732b22602cb596d44cb38418a196c3340be
+  - https://www.virustotal.com/gui/file/f85ce4492e1354f8310027c5f70ef73aae654fcd8fd9a58034e4f82a41a9826b/relations
+  - https://github.com/Still34/malware-lab/tree/main/reworkshop/2024-11-24
+Acknowledgements:
+  - Name: MalwareHunterTeam
+    Twitter: '@malwrhunterteam'
+  - Name: Still Hsu
+    Twitter: '@AzakaSekai_'
+


### PR DESCRIPTION
## Summary

This PR adds `zlibwapi.dll` and the vulnerable executable `dsclock.exe` that loads the library. The combination was recently spotted in a fake browser download campaign spread by Chinese actors.