### PR TITLE
 d3d11.dll side loaded by wallpaper32.exe 

### DIFF
--- a/yml/microsoft/built-in/d3d11.yml
+++ b/yml/microsoft/built-in/d3d11.yml
@@ -75,8 +75,8 @@ VulnerableExecutables:
     Issuer: CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     Type: Catalog
   - Path: '%ProgramFiles(x86)%\Steam\steamapps\common\wallpaper_engine\wallpaper32.exe'
-  Type: Sideloading
-   ExpectedSignatureInformation:
+    Type: Sideloading
+  ExpectedSignatureInformation:
   - Subject: CN="Skutta, Kristjan", O="Skutta, Kristjan", L=Berlin, C=DE
     Issuer: CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US
 Resources:

--- a/yml/microsoft/built-in/d3d11.yml
+++ b/yml/microsoft/built-in/d3d11.yml
@@ -71,14 +71,12 @@ VulnerableExecutables:
   Type: Sideloading
   AutoElevate: true
   ExpectedSignatureInformation:
-  - Subject: CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
-    Issuer: CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
-    Type: Catalog
-  - Path: '%ProgramFiles(x86)%\Steam\steamapps\common\wallpaper_engine\wallpaper32.exe'
-    Type: Sideloading
   ExpectedSignatureInformation:
   - Subject: CN="Skutta, Kristjan", O="Skutta, Kristjan", L=Berlin, C=DE
     Issuer: CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US
+    Type: Catalog
+  - Path: '%ProgramFiles(x86)%\Steam\steamapps\common\wallpaper_engine\wallpaper32.exe'
+    Type: Sideloading
 Resources:
 - https://wietze.github.io/blog/hijacking-dlls-in-windows
 - https://securityintelligence.com/posts/windows-features-dll-sideloading/

--- a/yml/microsoft/built-in/d3d11.yml
+++ b/yml/microsoft/built-in/d3d11.yml
@@ -86,6 +86,7 @@ Resources:
 - https://wietze.github.io/blog/hijacking-dlls-in-windows
 - https://securityintelligence.com/posts/windows-features-dll-sideloading/
 - https://github.com/xforcered/WFH
+- https://blog.amartinsec.com/blog/dllhijacking/
 Acknowledgements:
 - Name: Wietze
   Twitter: '@wietze'

--- a/yml/microsoft/built-in/d3d11.yml
+++ b/yml/microsoft/built-in/d3d11.yml
@@ -74,6 +74,11 @@ VulnerableExecutables:
   - Subject: CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     Issuer: CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     Type: Catalog
+  - Path: '%ProgramFiles(x86)%\Steam\steamapps\common\wallpaper_engine\wallpaper32.exe'
+  Type: Sideloading
+   ExpectedSignatureInformation:
+  - Subject: CN="Skutta, Kristjan", O="Skutta, Kristjan", L=Berlin, C=DE
+    Issuer: CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US
 Resources:
 - https://wietze.github.io/blog/hijacking-dlls-in-windows
 - https://securityintelligence.com/posts/windows-features-dll-sideloading/
@@ -83,3 +88,6 @@ Acknowledgements:
   Twitter: '@wietze'
 - Name: Chris Spehn
   Twitter: '@ConsciousHacker'
+- Name: Josh Allman
+  Company: Huntress
+  Twitter: '@xorjosh'

--- a/yml/microsoft/built-in/d3d11.yml
+++ b/yml/microsoft/built-in/d3d11.yml
@@ -76,6 +76,8 @@ VulnerableExecutables:
     Type: Catalog
 - Path: '%PROGRAMFILES%\Steam\steamapps\common\wallpaper_engine\wallpaper32.exe'
   Type: Sideloading
+  SHA256:
+  - 1b0d67730ad59a49715e39f904f4f59ea9e81a54ea51ab20e6ec473546708aa7
   ExpectedSignatureInformation:
   - Subject: CN="Skutta, Kristjan", O="Skutta, Kristjan", L=Berlin, C=DE
     Issuer: CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US

--- a/yml/microsoft/built-in/d3d11.yml
+++ b/yml/microsoft/built-in/d3d11.yml
@@ -71,11 +71,15 @@ VulnerableExecutables:
   Type: Sideloading
   AutoElevate: true
   ExpectedSignatureInformation:
-    - Subject: CN="Skutta, Kristjan", O="Skutta, Kristjan", L=Berlin, C=DE
-      Issuer: CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US
-      Type: Catalog
+  - Subject: CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
+    Issuer: CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
+    Type: Catalog
 - Path: '%ProgramFiles(x86)%\Steam\steamapps\common\wallpaper_engine\wallpaper32.exe'
   Type: Sideloading
+  ExpectedSignatureInformation:
+  - Subject: CN="Skutta, Kristjan", O="Skutta, Kristjan", L=Berlin, C=DE
+    Issuer: CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US
+    Type: Catalog
 Resources:
 - https://wietze.github.io/blog/hijacking-dlls-in-windows
 - https://securityintelligence.com/posts/windows-features-dll-sideloading/

--- a/yml/microsoft/built-in/d3d11.yml
+++ b/yml/microsoft/built-in/d3d11.yml
@@ -71,11 +71,11 @@ VulnerableExecutables:
   Type: Sideloading
   AutoElevate: true
   ExpectedSignatureInformation:
-  - Subject: CN="Skutta, Kristjan", O="Skutta, Kristjan", L=Berlin, C=DE
-    Issuer: CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US
-    Type: Catalog
-  - Path: '%ProgramFiles(x86)%\Steam\steamapps\common\wallpaper_engine\wallpaper32.exe'
-    Type: Sideloading
+    - Subject: CN="Skutta, Kristjan", O="Skutta, Kristjan", L=Berlin, C=DE
+      Issuer: CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US
+      Type: Catalog
+- Path: '%ProgramFiles(x86)%\Steam\steamapps\common\wallpaper_engine\wallpaper32.exe'
+  Type: Sideloading
 Resources:
 - https://wietze.github.io/blog/hijacking-dlls-in-windows
 - https://securityintelligence.com/posts/windows-features-dll-sideloading/

--- a/yml/microsoft/built-in/d3d11.yml
+++ b/yml/microsoft/built-in/d3d11.yml
@@ -74,7 +74,7 @@ VulnerableExecutables:
   - Subject: CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     Issuer: CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     Type: Catalog
-- Path: '%ProgramFiles(x86)%\Steam\steamapps\common\wallpaper_engine\wallpaper32.exe'
+- Path: '%PROGRAMFILES%\Steam\steamapps\common\wallpaper_engine\wallpaper32.exe'
   Type: Sideloading
   ExpectedSignatureInformation:
   - Subject: CN="Skutta, Kristjan", O="Skutta, Kristjan", L=Berlin, C=DE

--- a/yml/microsoft/built-in/d3d11.yml
+++ b/yml/microsoft/built-in/d3d11.yml
@@ -79,7 +79,7 @@ VulnerableExecutables:
   ExpectedSignatureInformation:
   - Subject: CN="Skutta, Kristjan", O="Skutta, Kristjan", L=Berlin, C=DE
     Issuer: CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US
-    Type: Catalog
+    Type: Authenticode
 Resources:
 - https://wietze.github.io/blog/hijacking-dlls-in-windows
 - https://securityintelligence.com/posts/windows-features-dll-sideloading/

--- a/yml/microsoft/built-in/d3d11.yml
+++ b/yml/microsoft/built-in/d3d11.yml
@@ -71,7 +71,6 @@ VulnerableExecutables:
   Type: Sideloading
   AutoElevate: true
   ExpectedSignatureInformation:
-  ExpectedSignatureInformation:
   - Subject: CN="Skutta, Kristjan", O="Skutta, Kristjan", L=Berlin, C=DE
     Issuer: CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US
     Type: Catalog


### PR DESCRIPTION
Huntress has observed WarZone RAT leveraging wall paper engine to load d3d11.dll
