### PR TITLE
Add Side loading msasn1.dll

### DIFF
--- a/yml/microsoft/built-in/msasn1.yml
+++ b/yml/microsoft/built-in/msasn1.yml
@@ -1,0 +1,22 @@
+Name: msasn1.dll
+Author: ice-wzl
+Created: 2025-04-04
+Vendor: Microsoft
+ExpectedLocations: # No trailing slashes
+  - '%SYSTEM32%'
+VulnerableExecutables:
+  - Path: 'winbox64.exe'
+    Type: Search Order
+    AutoElevate: true
+    Condition: 'version >= 3.41'
+  - Path: 'winbox.exe'
+    Type: Search Order
+    AutoElevate: true
+    Condition: 'version >= 3.41'
+Resources:
+  - https://ice-wzl.medium.com/mikrotik-winbox-dll-side-loading-vulnerability-9ed9420bd4d7
+  - https://github.com/pbatard/rufus/issues/1877
+Acknowledgements:
+  - Name: ice-wzl
+    Twitter: '@ice_wzl_cyber'
+  - ...

--- a/yml/microsoft/built-in/msasn1.yml
+++ b/yml/microsoft/built-in/msasn1.yml
@@ -2,7 +2,7 @@ Name: msasn1.dll
 Author: ice-wzl
 Created: 2025-04-04
 Vendor: Microsoft
-ExpectedLocations: # No trailing slashes
+ExpectedLocations:
   - '%SYSTEM32%'
 VulnerableExecutables:
   - Path: 'winbox64.exe'
@@ -19,4 +19,3 @@ Resources:
 Acknowledgements:
   - Name: ice-wzl
     Twitter: '@ice_wzl_cyber'
-  - ...


### PR DESCRIPTION
## Summary 
- Add `msasn1.dll` which `winbox.exe` and `winbox64.exe` will attempt to load from their present working directory before attempting to load the legitimate Windows DLL from its expected location, `%SYSTEM32%`
- Due to this app needing to modify the Windows FW rules to make connections to MikroTiks, it should be run with Administrator permissions.
- A longer write up of this issue can be found here: https://ice-wzl.medium.com/mikrotik-winbox-dll-side-loading-vulnerability-9ed9420bd4d7
- `rufus.exe` also appears to have this issue as referenced here: https://github.com/pbatard/rufus/issues/1877

- Thanks for maintaining a great reference site!