### PR TITLE
Add winbox64.exe

### DIFF
--- a/yml/microsoft/built-in/cryptbase.yml
+++ b/yml/microsoft/built-in/cryptbase.yml
@@ -229,12 +229,22 @@ VulnerableExecutables:
   - Subject: CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     Issuer: CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     Type: Catalog
+- Path: 'winbox64.exe'
+  Type: Sideloading
+  ExpectedSignatureInformation:
+  - Subject: CN = SIA "Mikrotīkls" O = SIA "Mikrotīkls" L = Riga C = LV 
+    Issuer: CN=DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1 O = DigiCert, Inc. C = US
+    Type: Catalog
+  SHA256:
+  - 8BC3ECF1F35952600ECB1A380C38C88E9D63C081A32204FD094D588230070BF6
+
 Resources:
 - https://wietze.github.io/blog/hijacking-dlls-in-windows
 - https://securityintelligence.com/posts/windows-features-dll-sideloading/
 - https://github.com/xforcered/WFH
 - https://twitter.com/AndrewOliveau/status/1682185200862625792
 - https://twitter.com/BSummerz/status/1860045985919205645
+- https://ice-wzl.medium.com/mikrotik-winbox-dll-side-loading-vulnerability-x2-413d371ff5f0
 Acknowledgements:
 - Name: Wietze
   Twitter: '@wietze'
@@ -244,3 +254,5 @@ Acknowledgements:
   Twitter: '@AndrewOliveau'
 - Name: Will Summerhill
   Twitter: '@BSummerz'
+- Name: ice-wzl
+  Twitter: '@ice_wzl_cyber'

--- a/yml/microsoft/built-in/cryptbase.yml
+++ b/yml/microsoft/built-in/cryptbase.yml
@@ -232,8 +232,8 @@ VulnerableExecutables:
 - Path: 'winbox64.exe'
   Type: Sideloading
   ExpectedSignatureInformation:
-  - Subject: CN = SIA "Mikrotīkls" O = SIA "Mikrotīkls" L = Riga C = LV
-    Issuer: CN=DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1 O = DigiCert, Inc. C = US
+  - Subject: CN=SIA "Mikrotīkls" O=SIA "Mikrotīkls" L=Riga C=LV
+    Issuer: CN=DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1 O=DigiCert, Inc. C=US
     Type: Catalog
   SHA256:
   - 8BC3ECF1F35952600ECB1A380C38C88E9D63C081A32204FD094D588230070BF6

--- a/yml/microsoft/built-in/cryptbase.yml
+++ b/yml/microsoft/built-in/cryptbase.yml
@@ -232,7 +232,7 @@ VulnerableExecutables:
 - Path: 'winbox64.exe'
   Type: Sideloading
   ExpectedSignatureInformation:
-  - Subject: CN = SIA "Mikrotīkls" O = SIA "Mikrotīkls" L = Riga C = LV 
+  - Subject: CN = SIA "Mikrotīkls" O = SIA "Mikrotīkls" L = Riga C = LV
     Issuer: CN=DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1 O = DigiCert, Inc. C = US
     Type: Catalog
   SHA256:


### PR DESCRIPTION
- I noticed that `winbox64.exe` also attempts to load `cryptbase.dll`. `winbox64.exe` is downloaded as a standalone executable, meaning that it is often found on users' Desktops/Downloads folder (due to it not having an installer). Please see: https://ice-wzl.medium.com/mikrotik-winbox-dll-side-loading-vulnerability-x2-413d371ff5f0 for a longer walk through.

- Thanks again for a great repo!