### PR TITLE
feat: Phatom DLL loading of offdmpsvc.dll by WerMgr.exe

### DIFF
--- a/yml/microsoft/built-in/offdmpsvc.yml
+++ b/yml/microsoft/built-in/offdmpsvc.yml
@@ -19,6 +19,5 @@ VulnerableExecutables:
 Resources:
   - https://www.hexacorn.com/blog/2025/06/14/wermgr-exe-boot-offdmpsvc-dll-lolbin/
 Acknowledgements:
-  - Name: 'Adam'
-    Company: 'HexaCorn'
-    Twitter: '@HexaCorn'
+  - Name: 'Hexacorn'
+    Twitter: '@Hexacorn'

--- a/yml/microsoft/built-in/offdmpsvc.yml
+++ b/yml/microsoft/built-in/offdmpsvc.yml
@@ -3,7 +3,7 @@ Name: offdmpsvc.dll
 Author: Swachchhanda Shrawan Poudel
 Created: 2025-06-17
 Vendor: Microsoft
-ExpectedLocations:  
+ExpectedLocations:
   - '%SYSTEM32%'
 VulnerableExecutables:
   - Path: '%SYSTEM32%\wermgr.exe'

--- a/yml/microsoft/built-in/offdmpsvc.yml
+++ b/yml/microsoft/built-in/offdmpsvc.yml
@@ -3,13 +3,12 @@ Name: offdmpsvc.dll
 Author: Swachchhanda Shrawan Poudel
 Created: 2025-06-17
 Vendor: Microsoft
-ExpectedLocations:
-  - 'C:\Windows\System32'
+ExpectedLocations:  
   - '%SYSTEM32%'
 VulnerableExecutables:
   - Path: '%SYSTEM32%\wermgr.exe'
     Type: 'Phantom'
-    Condition: wermgr -boot
+    Condition: Triggers via `wermgr -boot`
     ExpectedVersionInformation:
       - CompanyName: 'Microsoft Corporation'
         FileDescription: 'Windows Problem Reporting'

--- a/yml/microsoft/built-in/offdmpsvc.yml
+++ b/yml/microsoft/built-in/offdmpsvc.yml
@@ -1,0 +1,24 @@
+---
+Name: offdmpsvc.dll
+Author: Swachchhanda Shrawan Poudel
+Created: 2025-06-17
+Vendor: Microsoft
+ExpectedLocations:
+  - 'C:\Windows\System32'
+VulnerableExecutables:
+  - Path: '%systemroot%\system32\wermgr.exe'
+    Type: 'Phantom'
+    Condition: wermgr -boot
+    ExpectedVersionInformation:
+      - CompanyName: 'Microsoft Corporation'
+        FileDescription: 'Windows Problem Reporting'
+        InternalName: 'WerMgr'
+        LegalCopyright: '© Microsoft Corporation. All rights reserved.'
+        OriginalFilename: 'WerMgr'
+        ProductName: 'Microsoft® Windows® Operating System'
+Resources:
+  - https://www.hexacorn.com/blog/2025/06/14/wermgr-exe-boot-offdmpsvc-dll-lolbin/
+Acknowledgements:
+  - Name: 'Adam'
+    Company: 'HexaCorn'
+    Twitter: '@HexaCorn'

--- a/yml/microsoft/built-in/offdmpsvc.yml
+++ b/yml/microsoft/built-in/offdmpsvc.yml
@@ -5,8 +5,9 @@ Created: 2025-06-17
 Vendor: Microsoft
 ExpectedLocations:
   - 'C:\Windows\System32'
+  - '%SYSTEM32%'
 VulnerableExecutables:
-  - Path: '%systemroot%\system32\wermgr.exe'
+  - Path: '%SYSTEM32%\wermgr.exe'
     Type: 'Phantom'
     Condition: wermgr -boot
     ExpectedVersionInformation:


### PR DESCRIPTION
According to https://www.hexacorn.com/blog/2025/06/14/wermgr-exe-boot-offdmpsvc-dll-lolbin/, wermgr.exe is vulnerable to phantom DLL loading through offdmpsvc.dll.