### PR TITLE
update: msvcr100.dll sideload

### DIFF
--- a/yml/microsoft/built-in/msvcr100.yml
+++ b/yml/microsoft/built-in/msvcr100.yml
@@ -19,7 +19,7 @@ VulnerableExecutables:
   ExpectedSignatureInformation:
   - Type: Authenticode
     Subject: CN=Microsoft Code Signing PCA,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US
-    Issuer: CN=Microsoft Root Authority,OU=Microsoft Corporation,OU=Copyright (c) 1997 Microsoft Corp.  
+    Issuer: CN=Microsoft Root Authority,OU=Microsoft Corporation,OU=Copyright (c) 1997 Microsoft Corp.
   Type: Search Order
 Resources:
 - https://twitter.com/SBousseaden/status/1530595156055011330

--- a/yml/microsoft/built-in/msvcr100.yml
+++ b/yml/microsoft/built-in/msvcr100.yml
@@ -13,6 +13,10 @@ VulnerableExecutables:
   SHA256:
   - 16f099aaff99f981741e299be6aff43f2e53b189481a08582e3b2a04e934aa0a
   Type: Sideloading
+- Path: 'cleanospp_64.exe'
+  SHA256:
+  - edf85f4e2ef1a427b34265a22f261d664ec78de90c3b5da4174ef28558c8522a
+  Type: Sideloading
 Resources:
 - https://twitter.com/SBousseaden/status/1530595156055011330
 - https://twitter.com/sbousseaden/status/1604934564614381571
@@ -20,3 +24,5 @@ Resources:
 Acknowledgements:
 - Name: Samir
   Twitter: '@sbousseaden'
+- Name: kinako
+  Twitter: '@kinako_software'

--- a/yml/microsoft/built-in/msvcr100.yml
+++ b/yml/microsoft/built-in/msvcr100.yml
@@ -16,7 +16,11 @@ VulnerableExecutables:
 - Path: 'cleanospp_64.exe'
   SHA256:
   - edf85f4e2ef1a427b34265a22f261d664ec78de90c3b5da4174ef28558c8522a
-  Type: Sideloading
+  ExpectedSignatureInformation:
+  - Type: Authenticode
+    Subject: CN=Microsoft Code Signing PCA,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US
+    Issuer: CN=Microsoft Root Authority,OU=Microsoft Corporation,OU=Copyright (c) 1997 Microsoft Corp.  
+  Type: Search Order
 Resources:
 - https://twitter.com/SBousseaden/status/1530595156055011330
 - https://twitter.com/sbousseaden/status/1604934564614381571


### PR DESCRIPTION
Hello @wietze ,
I happened to discover that the signed binary cleanospp_64.exe, distributed by Microsoft, is vulnerable to DLL sideloading via msvcr100.dll.
The binary can be downloaded from the following URL:
https://www.microsoft.com/en-us/download/details.aspx?id=103391

I would appreciate it if you could take a moment to review this commit. Thank you!

