### PR TITLE
OneDrive DLL sideloading using sspicli.dll

### DIFF
--- a/yml/microsoft/built-in/sspicli.yml
+++ b/yml/microsoft/built-in/sspicli.yml
@@ -366,6 +366,8 @@ Resources:
 - https://wietze.github.io/blog/save-the-environment-variables
 - https://securityintelligence.com/posts/windows-features-dll-sideloading/
 - https://github.com/xforcered/WFH
+- https://lab52.io/blog/analyzing-notdoor-inside-apt28s-expanding-arsenal/
+- https://www.legit4n6.com/OneDrive-SSPICLI-dll-Side-Loading-Proof-of-Concept-264d60e66daf80caa347f437baf5edf3
 Acknowledgements:
 - Name: Wietze
   Twitter: '@wietze'


### PR DESCRIPTION
OneDrive also loads sspicli.dll from system32 and can sideload a malicious dll this way. I created a POC to test this out - 
[POC testing](https://www.legit4n6.com/OneDrive-SSPICLI-dll-Side-Loading-Proof-of-Concept-264d60e66daf80caa347f437baf5edf3)

The idea came from a recent [LAB52 article](https://lab52.io/blog/analyzing-notdoor-inside-apt28s-expanding-arsenal/) with an example of malicious use.