### PR TITLE
Remove SamsungDriver from expected location for cnmpaui

### DIFF
--- a/yml/3rd_party/canon/cnmpaui.yml
+++ b/yml/3rd_party/canon/cnmpaui.yml
@@ -5,7 +5,6 @@ Created: 2025-09-08
 Vendor: Canon
 ExpectedLocations:
   - '%PROGRAMFILES%\Canon\Canon IJ Printer Assistant Tool\'
-  - '%USERPROFILE%\AppData\Roaming\SamsungDriver\'
 VulnerableExecutables:
   - Path: 'cnmpaui.exe'
     Type: Sideloading


### PR DESCRIPTION
## Summary

As previously mentioned in #142, the launcher is normally *not* expected to be under the `SamsungDriver` path from the legitimate software. This path is *only* expected for the MiniPlug/PlugDisk series of malware.