### PR TITLE
Add vcruntime140_1.dll entry (LICLUA.EXE sideload witness)

### DIFF
--- a/yml/microsoft/built-in/vcruntime140.yml
+++ b/yml/microsoft/built-in/vcruntime140.yml
@@ -1,34 +1,24 @@
 ---
-Name: vcruntime140.dll
-Author: Swachchhanda Shrawan Poudel
-Created: 2026-01-06
-Vendor: Microsoft
-ExpectedLocations:
-- '%SYSTEM32%'
-VulnerableExecutables:
-- Path: '%PROGRAMFILES%\Microsoft SQL Server\%VERSION%\Shared\sqlwriter.exe'
-  Type: Sideloading
-  SHA256:
-    - 8d1d449a0bd5b2085c52e4662e5999d2163f8e2b7a73874329fb4f01a397d7ab
-- Path: '%PROGRAMFILES%\Microsoft SQL Server\%VERSION%\Shared\SqlDumper.exe'
-  Type: Sideloading
-  SHA256:
-    - 116866708b5c22d643427203e7b0b023ccee8effeec8801638421bf96e569813
-- Path: '%PROGRAMFILES%\Common Files\Microsoft Shared\OFFICE16\LICLUA.exe'
-  Type: Sideloading
-  SHA256:
-    - aa07502bc2118083b057996bdc8a026c3b2f0757fac326fc7d13b05b80504246
-  ExpectedVersionInformation:
-    - FileVersion: '16.0.17932.20842'
-      ProductName: 'Office Licensing Admin Access Provider'
-      InternalName: 'liclua.exe'
-      OriginalFilename: 'liclua.exe'
-Resources:
-- https://www.zscaler.com/blogs/security-research/european-diplomats-targeted-apt29-cozy-bear-wineloader
-- https://cloud.google.com/blog/topics/threat-intelligence/apt29-wineloader-german-political-parties
-- https://connar.github.io/posts/dll-hijacking-journey/
-Acknowledgements:
-- Name: Swachchhanda Shrawan Poudel
-  Twitter: '@_swachchhanda_'
-  Company: Nextron Systems
-- Name: connar
+    Name: vcruntime140.dll
+    Author: Swachchhanda Shrawan Poudel
+    Created: 2026-01-06
+    Vendor: Microsoft
+    ExpectedLocations:
+    - '%SYSTEM32%'
+    VulnerableExecutables:
+    - Path: '%PROGRAMFILES%\Microsoft SQL Server\%VERSION%\Shared\sqlwriter.exe'
+      Type: Sideloading
+      SHA256:
+        - 8d1d449a0bd5b2085c52e4662e5999d2163f8e2b7a73874329fb4f01a397d7ab
+    - Path: '%PROGRAMFILES%\Microsoft SQL Server\%VERSION%\Shared\SqlDumper.exe'
+      Type: Sideloading
+      SHA256:
+        - 116866708b5c22d643427203e7b0b023ccee8effeec8801638421bf96e569813
+
+    Resources:
+    - https://www.zscaler.com/blogs/security-research/european-diplomats-targeted-apt29-cozy-bear-wineloader
+    - https://cloud.google.com/blog/topics/threat-intelligence/apt29-wineloader-german-political-parties
+    Acknowledgements:
+    - Name: Swachchhanda Shrawan Poudel
+      Twitter: '@_swachchhanda_'
+      Company: Nextron Systems

--- a/yml/microsoft/built-in/vcruntime140.yml
+++ b/yml/microsoft/built-in/vcruntime140.yml
@@ -14,10 +14,21 @@ VulnerableExecutables:
   Type: Sideloading
   SHA256:
     - 116866708b5c22d643427203e7b0b023ccee8effeec8801638421bf96e569813
+- Path: '%PROGRAMFILES%\Common Files\Microsoft Shared\OFFICE16\LICLUA.exe'
+  Type: Sideloading
+  SHA256:
+    - aa07502bc2118083b057996bdc8a026c3b2f0757fac326fc7d13b05b80504246
+  ExpectedVersionInformation:
+    - FileVersion: '16.0.17932.20842'
+      ProductName: 'Office Licensing Admin Access Provider'
+      InternalName: 'liclua.exe'
+      OriginalFilename: 'liclua.exe'
 Resources:
 - https://www.zscaler.com/blogs/security-research/european-diplomats-targeted-apt29-cozy-bear-wineloader
 - https://cloud.google.com/blog/topics/threat-intelligence/apt29-wineloader-german-political-parties
+- https://connar.github.io/posts/dll-hijacking-journey/
 Acknowledgements:
 - Name: Swachchhanda Shrawan Poudel
   Twitter: '@_swachchhanda_'
   Company: Nextron Systems
+- Name: connar

--- a/yml/microsoft/built-in/vcruntime140.yml
+++ b/yml/microsoft/built-in/vcruntime140.yml
@@ -14,7 +14,6 @@ VulnerableExecutables:
   Type: Sideloading
   SHA256:
     - 116866708b5c22d643427203e7b0b023ccee8effeec8801638421bf96e569813
-
 Resources:
 - https://www.zscaler.com/blogs/security-research/european-diplomats-targeted-apt29-cozy-bear-wineloader
 - https://cloud.google.com/blog/topics/threat-intelligence/apt29-wineloader-german-political-parties

--- a/yml/microsoft/built-in/vcruntime140.yml
+++ b/yml/microsoft/built-in/vcruntime140.yml
@@ -1,24 +1,24 @@
 ---
-    Name: vcruntime140.dll
-    Author: Swachchhanda Shrawan Poudel
-    Created: 2026-01-06
-    Vendor: Microsoft
-    ExpectedLocations:
-    - '%SYSTEM32%'
-    VulnerableExecutables:
-    - Path: '%PROGRAMFILES%\Microsoft SQL Server\%VERSION%\Shared\sqlwriter.exe'
-      Type: Sideloading
-      SHA256:
-        - 8d1d449a0bd5b2085c52e4662e5999d2163f8e2b7a73874329fb4f01a397d7ab
-    - Path: '%PROGRAMFILES%\Microsoft SQL Server\%VERSION%\Shared\SqlDumper.exe'
-      Type: Sideloading
-      SHA256:
-        - 116866708b5c22d643427203e7b0b023ccee8effeec8801638421bf96e569813
+Name: vcruntime140.dll
+Author: Swachchhanda Shrawan Poudel
+Created: 2026-01-06
+Vendor: Microsoft
+ExpectedLocations:
+- '%SYSTEM32%'
+VulnerableExecutables:
+- Path: '%PROGRAMFILES%\Microsoft SQL Server\%VERSION%\Shared\sqlwriter.exe'
+  Type: Sideloading
+  SHA256:
+    - 8d1d449a0bd5b2085c52e4662e5999d2163f8e2b7a73874329fb4f01a397d7ab
+- Path: '%PROGRAMFILES%\Microsoft SQL Server\%VERSION%\Shared\SqlDumper.exe'
+  Type: Sideloading
+  SHA256:
+    - 116866708b5c22d643427203e7b0b023ccee8effeec8801638421bf96e569813
 
-    Resources:
-    - https://www.zscaler.com/blogs/security-research/european-diplomats-targeted-apt29-cozy-bear-wineloader
-    - https://cloud.google.com/blog/topics/threat-intelligence/apt29-wineloader-german-political-parties
-    Acknowledgements:
-    - Name: Swachchhanda Shrawan Poudel
-      Twitter: '@_swachchhanda_'
-      Company: Nextron Systems
+Resources:
+- https://www.zscaler.com/blogs/security-research/european-diplomats-targeted-apt29-cozy-bear-wineloader
+- https://cloud.google.com/blog/topics/threat-intelligence/apt29-wineloader-german-political-parties
+Acknowledgements:
+- Name: Swachchhanda Shrawan Poudel
+  Twitter: '@_swachchhanda_'
+  Company: Nextron Systems

--- a/yml/microsoft/built-in/vcruntime140_1.yml
+++ b/yml/microsoft/built-in/vcruntime140_1.yml
@@ -1,0 +1,42 @@
+---
+Name: vcruntime140_1.dll
+Author: connar
+Created: 2026-07-14
+Vendor: Microsoft
+ExpectedLocations:
+  - '%SYSTEM32%'
+  - '%SYSWOW64%'
+ExpectedVersionInformation:
+  - CompanyName: 'Microsoft Corporation'
+    FileDescription: 'Microsoft® C Runtime Library'
+    FileVersion: '14.44.35211.0'
+    InternalName: 'vcruntime140_1.dll'
+    LegalCopyright: '© Microsoft Corporation. All rights reserved.'
+    OriginalFilename: 'vcruntime140_1.dll'
+    ProductName: 'Microsoft® Visual Studio®'
+    ProductVersion: '14.44.35211.0'
+ExpectedSignatureInformation:
+  - Type: Authenticode
+    Subject: CN=Microsoft Windows Software Compatibility Publisher,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US
+    Issuer: CN=Microsoft Windows Third Party Component CA 2013,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US
+VulnerableExecutables:
+  - Path: '%PROGRAMFILES%\Common Files\Microsoft Shared\OFFICE16\LICLUA.exe'
+    Type: 'Sideloading'
+    SHA256:
+      - aa07502bc2118083b057996bdc8a026c3b2f0757fac326fc7d13b05b80504246
+    ExpectedVersionInformation:
+      - CompanyName: 'Microsoft Corporation'
+        FileDescription: 'Office Licensing Admin Access Provider'
+        FileVersion: '16.0.17932.20842'
+        InternalName: 'liclua.exe'
+        OriginalFilename: 'liclua.exe'
+        ProductName: 'Office Licensing Admin Access Provider'
+        ProductVersion: '16.0.17932.20842'
+    ExpectedSignatureInformation:
+      - Type: Authenticode
+        Subject: CN=Microsoft Windows Software Compatibility Publisher,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US
+        Issuer: CN=Microsoft Windows Third Party Component CA 2013,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US
+Resources:
+  - https://connar.github.io/posts/dll-hijacking-journey/
+Acknowledgements:
+  - Name: 'connar'


### PR DESCRIPTION
Adds a new library entry for vcruntime140_1.dll with LICLUA.EXE (Office Licensing Admin Access Provider of Microsoft) as the initial witness executable.
LICLUA is a signed Microsoft binary that loads vcruntime140_1.dll (along with vcruntime140.dll and msvcp140.dll, which I'll submit as separate updates) from its application directory before falling back to System32. Loader behavior confirmed via Process Monitor.
Same-privilege sideload on default install, impact scoping is in the linked writeup.