### PR TITLE
Add libcrypto-3-x64.dll sideloading entry (VMware vmware-vmx.exe)

### DIFF
--- a/yml/3rd_party/vmware/libcrypto-3-x64.yml
+++ b/yml/3rd_party/vmware/libcrypto-3-x64.yml
@@ -1,0 +1,22 @@
+Name: libcrypto-3-x64.dll
+Author: Harry Godridge - HuntressLabs
+Created: 2026-07-15
+Vendor: VMware
+ExpectedLocations:
+  - '%PROGRAMFILES%\VMware\VMware Workstation\x64'
+  - '%PROGRAMFILES%\VMware\VMware Workstation'
+VulnerableExecutables:
+  - Path: '%PROGRAMFILES%\VMware\VMware Workstation\x64\vmware-vmx.exe'
+    Type: Sideloading
+    ExpectedVersionInformation:
+      - OriginalFilename: vmware-vmx.exe
+        FileDescription: VMware Workstation VMX
+    SHA256:
+      - '745870f6b3e20e1cd5c022f2813f28bbd04195fc93f9f4a42f73719a43db9463'
+Acknowledgements:
+  - Name: Harry Godridge
+    Company: Huntress
+    Twitter: '@InfoSecHarry'
+  - Name: Josh Allman
+    Company: Huntress
+    Twitter: '@xorjosh'

--- a/yml/3rd_party/vmware/libcrypto-3-x64.yml
+++ b/yml/3rd_party/vmware/libcrypto-3-x64.yml
@@ -13,6 +13,8 @@ VulnerableExecutables:
         FileDescription: VMware Workstation VMX
     SHA256:
       - '745870f6b3e20e1cd5c022f2813f28bbd04195fc93f9f4a42f73719a43db9463'
+Resources:
+  - https://www.virustotal.com/gui/file/4037e6f00a09839d398ffc322abf4ef34facb7ece4dae4a011fa72fc6492c78f      
 Acknowledgements:
   - Name: Harry Godridge
     Company: Huntress

--- a/yml/3rd_party/vmware/libcrypto-3-x64.yml
+++ b/yml/3rd_party/vmware/libcrypto-3-x64.yml
@@ -1,3 +1,4 @@
+---
 Name: libcrypto-3-x64.dll
 Author: Harry Godridge - HuntressLabs
 Created: 2026-07-15
@@ -14,7 +15,7 @@ VulnerableExecutables:
     SHA256:
       - '745870f6b3e20e1cd5c022f2813f28bbd04195fc93f9f4a42f73719a43db9463'
 Resources:
-  - https://www.virustotal.com/gui/file/4037e6f00a09839d398ffc322abf4ef34facb7ece4dae4a011fa72fc6492c78f      
+  - https://www.virustotal.com/gui/file/4037e6f00a09839d398ffc322abf4ef34facb7ece4dae4a011fa72fc6492c78f
 Acknowledgements:
   - Name: Harry Godridge
     Company: Huntress


### PR DESCRIPTION
### New entry: libcrypto-3-x64.dll

Adds a new DLL hijacking entry documenting a **sideloading** opportunity via the legitimate VMware Workstation binary `vmware-vmx.exe`, which loads `libcrypto-3-x64.dll`.

**Details**
- **DLL:** `libcrypto-3-x64.dll`
- **Vendor:** VMware
- **Vulnerable executable:** `vmware-vmx.exe` (FileDescription "VMware Workstation VMX")
- **Type:** Sideloading
- **Expected locations:** `%PROGRAMFILES%\VMware\VMware Workstation\x64` and `%PROGRAMFILES%\VMware\VMware Workstation`

**File**
- `yml/3rd_party/vmware/libcrypto-3-x64.yml`

Submitted by Harry Godridge (Huntress).