### PR TITLE
Add wblindp2.dll sideloading entry (Stardock WindowBlinds WB11Config.exe)

### DIFF
--- a/yml/3rd_party/stardock/wblindp2.yml
+++ b/yml/3rd_party/stardock/wblindp2.yml
@@ -1,0 +1,19 @@
+Name: wblindp2.dll
+Author: Harry Godridge - HuntressLabs
+Created: 2026-07-30
+Vendor: Stardock
+ExpectedLocations:
+  - '%PROGRAMFILES%\Stardock\WindowBlinds'
+VulnerableExecutables:
+  - Path: '%PROGRAMFILES%\Stardock\WindowBlinds\WB11Config.exe'
+    Type: Sideloading
+    ExpectedVersionInformation:
+      - OriginalFilename: WB11Config.exe
+        CompanyName: Stardock Systems, Inc.
+        ProductName: WindowBlinds
+    SHA256:
+      - '19d78cd26cbfeb0800508063359f149f271fd7904d1ee0983ec24ba9efcb11e5'
+Acknowledgements:
+  - Name: Harry Godridge
+    Company: Huntress
+    Twitter: '@InfoSecHarry'

--- a/yml/3rd_party/stardock/wblindp2.yml
+++ b/yml/3rd_party/stardock/wblindp2.yml
@@ -1,3 +1,4 @@
+---
 Name: wblindp2.dll
 Author: Harry Godridge - HuntressLabs
 Created: 2026-07-30

--- a/yml/3rd_party/stardock/wblindp2.yml
+++ b/yml/3rd_party/stardock/wblindp2.yml
@@ -14,6 +14,8 @@ VulnerableExecutables:
         ProductName: WindowBlinds
     SHA256:
       - '19d78cd26cbfeb0800508063359f149f271fd7904d1ee0983ec24ba9efcb11e5'
+Resources:
+  - https://www.virustotal.com/gui/file/46119283e93efcc926ab808fb711b64393caab9e5aab78ceae02aa7402e47373/relations
 Acknowledgements:
   - Name: Harry Godridge
     Company: Huntress


### PR DESCRIPTION
### New entry: wblindp2.dll

Adds a new DLL hijacking entry documenting a **sideloading** opportunity via the legitimate, Stardock-signed `WB11Config.exe` (the WindowBlinds 11 configuration utility), which loads `wblindp2.dll` from its application directory.

**Details**
- **DLL:** `wblindp2.dll` (ships legitimately in the WindowBlinds install folder)
- **Vendor:** Stardock
- **Vulnerable executable:** `WB11Config.exe` (OriginalFilename `WB11Config.exe`, CompanyName "Stardock Systems, Inc.", ProductName "WindowBlinds")
- **Type:** Sideloading
- **Expected location:** `%PROGRAMFILES%\Stardock\WindowBlinds`

**File**
- `yml/3rd_party/stardock/wblindp2.yml`

Submitted by Harry Godridge (Huntress).