### PR TITLE
Adding OneDrive to wtsapi32

### DIFF
--- a/yml/microsoft/built-in/wtsapi32.yml
+++ b/yml/microsoft/built-in/wtsapi32.yml
@@ -118,8 +118,8 @@ VulnerableExecutables:
   - Subject: CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     Issuer: CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     Type: Catalog
-- Path: '%LocalAppData%\Microsoft\OneDrive\OneDrive.exe'
-  Type: Sideloading
+- Path: '%LOCALAPPDATA%\Microsoft\OneDrive\OneDrive.exe'
+  Type: Search Order
 Resources:
 - https://wietze.github.io/blog/hijacking-dlls-in-windows
 - https://securityintelligence.com/posts/windows-features-dll-sideloading/

--- a/yml/microsoft/built-in/wtsapi32.yml
+++ b/yml/microsoft/built-in/wtsapi32.yml
@@ -129,8 +129,10 @@ Acknowledgements:
 - Name: Wietze
   Twitter: '@wietze'
 - Name: Chris Spehn
-- Name: Daniel Koifman
   Twitter: '@ConsciousHacker'
 - Name: Austin Worline
   Company: Huntress
   Twitter: '@0xffaraday'
+- Name: Daniel Koifman
+  Company: Cribl
+  Twitter: '@KoifSec'

--- a/yml/microsoft/built-in/wtsapi32.yml
+++ b/yml/microsoft/built-in/wtsapi32.yml
@@ -118,14 +118,18 @@ VulnerableExecutables:
   - Subject: CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     Issuer: CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     Type: Catalog
+- Path: '%LocalAppData%\Microsoft\OneDrive\OneDrive.exe'
+  Type: Sideloading
 Resources:
 - https://wietze.github.io/blog/hijacking-dlls-in-windows
 - https://securityintelligence.com/posts/windows-features-dll-sideloading/
 - https://github.com/xforcered/WFH
+- https://www.zscaler.com/blogs/security-research/c2looper-new-backdoor-likely-tied-ransomware-github-c2
 Acknowledgements:
 - Name: Wietze
   Twitter: '@wietze'
 - Name: Chris Spehn
+- Name: Daniel Koifman
   Twitter: '@ConsciousHacker'
 - Name: Austin Worline
   Company: Huntress


### PR DESCRIPTION
Based on https://www.zscaler.com/blogs/security-research/c2looper-new-backdoor-likely-tied-ransomware-github-c2

"Downloads a PE file from a specified URL to the compromised host and saves it as the filename wtsapi32.dll under the path %LocalAppData%\Microsoft\OneDrive\. C2Looper then terminates the OneDrive process and abuses a legitimate OneDrive executable to load the malicious DLL."