### PR TITLE
Add maxkernl.dll sideloading entry (Nuance PaperPort PPScanMg.exe)

### DIFF
--- a/yml/3rd_party/nuance/maxkernl.yml
+++ b/yml/3rd_party/nuance/maxkernl.yml
@@ -1,0 +1,27 @@
+---
+Name: maxkernl.dll
+Author: Harry Godridge - HuntressLabs
+Created: 2026-08-27
+Vendor: Nuance
+ExpectedLocations:
+  - '%PROGRAMFILES%\Nuance\PaperPort'
+VulnerableExecutables:
+  - Path: '%PROGRAMFILES%\Nuance\PaperPort\PPScanMg.exe'
+    Type: Sideloading
+    SHA256:
+      - '33b9c9d312599096ff03e7111501d8c10624d3471f62180767b965b9cfaafc82'
+    ExpectedVersionInformation:
+      - FileDescription: 'PaperPort Scan Manager'
+        FileVersion: '14.5.15069.1503'
+        InternalName: 'PPScanMg'
+        LegalCopyright: '(c) 1995-2015, Nuance Communications, Inc.'
+        OriginalFilename: 'PPScanMg.exe'
+        ProductName: 'PaperPort'
+    ExpectedSignatureInformation:
+      - Type: Authenticode
+        Subject: 'CN="Nuance Communications, Inc."'
+        Issuer: 'CN=Go Daddy Secure Certification Authority'
+Acknowledgements:
+  - Name: Harry Godridge
+    Company: Huntress
+    Twitter: '@InfoSecHarry'


### PR DESCRIPTION
### New entry: maxkernl.dll

Adds a new DLL hijacking entry documenting a **sideloading** opportunity via the legitimate, Nuance-signed `PPScanMg.exe` (PaperPort Scan Manager), which loads `maxkernl.dll` from its application directory.

**Details**
- **DLL:** `maxkernl.dll` (PaperPort File & Rendering component; present in PPScanMg.exe's import table)
- **Vendor:** Nuance
- **Vulnerable executable:** `PPScanMg.exe` (ProductName "PaperPort", FileDescription "PaperPort Scan Manager", v14.5.15069.1503), signed by Nuance Communications, Inc.
- **Type:** Sideloading
- **Expected location:** `%PROGRAMFILES%\Nuance\PaperPort`

**File**
- `yml/3rd_party/nuance/maxkernl.yml`

**Notes**
- Observed in the wild where the legitimate signed `PPScanMg.exe` was renamed to `CompElect.exe` and used to sideload a malicious `maxkernl.dll` for code execution.

Submitted by Harry Godridge (Huntress).